### PR TITLE
Make mountpoint parameter optional

### DIFF
--- a/scripts/manager.py
+++ b/scripts/manager.py
@@ -192,7 +192,7 @@ class Manager(object):
             config = ConfigParser.RawConfigParser()
             config.read('/etc/zfssnapmanager.cfg')
             for dataset in config.sections():
-                settings[dataset] = {'mountpoint': config.get(dataset, 'mountpoint'),
+                settings[dataset] = {'mountpoint': config.get(dataset, 'mountpoint') if config.has_option(dataset, 'mountpoint') else None,
                                      'time': config.get(dataset, 'time'),
                                      'snapshot': config.getboolean(dataset, 'snapshot'),
                                      'replicate': None,


### PR DESCRIPTION
mountpoint only needs to be defined if using the trigger option